### PR TITLE
Threading fixes

### DIFF
--- a/src/rasta/c/logging.c
+++ b/src/rasta/c/logging.c
@@ -61,8 +61,6 @@ char * get_log_message_string(log_level max_log_level, log_level level, char * l
         return NULL;
     }
 
-    // localtime is not thread-safe
-
     // generate timestamp
     time_t current_time = time(NULL);
     struct tm tt;
@@ -116,8 +114,6 @@ char * get_log_message_string(log_level max_log_level, log_level level, char * l
 void * write_log_messages(void * logger_ptr){
     // enable possibility to cancel thread
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-
-    // set cancel type to async, i.e. can always be canceled
     pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
 
     write_thread_parameter_wrapper * wrapper = (write_thread_parameter_wrapper *)logger_ptr;

--- a/src/rasta/c/logging.c
+++ b/src/rasta/c/logging.c
@@ -115,7 +115,7 @@ void * write_log_messages(void * logger_ptr){
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
     // set cancel type to async, i.e. can always be canceled
-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
 
     write_thread_parameter_wrapper * wrapper = (write_thread_parameter_wrapper *)logger_ptr;
 
@@ -277,6 +277,7 @@ void logger_destroy(struct logger_t * logger){
     }
 
     pthread_cancel(logger->write_thread);
+    pthread_join(logger->write_thread, NULL);
 
     pthread_mutex_destroy(&logger->mutex);
 

--- a/src/rasta/c/logging.c
+++ b/src/rasta/c/logging.c
@@ -64,19 +64,20 @@ char * get_log_message_string(log_level max_log_level, log_level level, char * l
     // localtime is not thread-safe
 
     // generate timestamp
-    // time_t current_time = time(NULL);
-    // struct tm * time_info = localtime(&current_time);
-    // char timestamp[30];
-    // char timestamp2[60];
+    time_t current_time = time(NULL);
+    struct tm tt;
+    struct tm * time_info = localtime_r(&current_time, &tt);
+    char timestamp[30];
+    char timestamp2[60];
 
-    // // ms since 1.1.1970
-    // struct timeval tv;
+    // ms since 1.1.1970
+    struct timeval tv;
 
-    // gettimeofday(&tv, NULL);
+    gettimeofday(&tv, NULL);
 
-    // unsigned long long millisecondsSinceEpoch =
-    //         (unsigned long long)(tv.tv_sec) * 1000 +
-    //         (unsigned long long)(tv.tv_usec) / 1000;
+    unsigned long long millisecondsSinceEpoch =
+            (unsigned long long)(tv.tv_sec) * 1000 +
+            (unsigned long long)(tv.tv_usec) / 1000;
 
 
     // generate log level string
@@ -96,13 +97,13 @@ char * get_log_message_string(log_level max_log_level, log_level level, char * l
     }
 
     // format timestamp
-    // strftime(timestamp, sizeof(timestamp), "%x|%X", time_info);
+    strftime(timestamp, sizeof(timestamp), "%x|%X", time_info);
 
     // add milliseconds to timestamp
-    // sprintf(timestamp2, "%s (Epoch time: %llu)", timestamp, millisecondsSinceEpoch);
+    sprintf(timestamp2, "%s (Epoch time: %llu)", timestamp, millisecondsSinceEpoch);
 
     char *  msg_string = rmalloc(LOGGER_MAX_MSG_SIZE);
-    sprintf(msg_string, LOG_FORMAT, "", level_str, location, msg_str);
+    sprintf(msg_string, LOG_FORMAT, timestamp2, level_str, location, msg_str);
 
     return msg_string;
 }

--- a/src/rasta/c/logging.c
+++ b/src/rasta/c/logging.c
@@ -61,20 +61,22 @@ char * get_log_message_string(log_level max_log_level, log_level level, char * l
         return NULL;
     }
 
+    // localtime is not thread-safe
+
     // generate timestamp
-    time_t current_time = time(NULL);
-    struct tm * time_info = localtime(&current_time);
-    char timestamp[30];
-    char timestamp2[60];
+    // time_t current_time = time(NULL);
+    // struct tm * time_info = localtime(&current_time);
+    // char timestamp[30];
+    // char timestamp2[60];
 
-    // ms since 1.1.1970
-    struct timeval tv;
+    // // ms since 1.1.1970
+    // struct timeval tv;
 
-    gettimeofday(&tv, NULL);
+    // gettimeofday(&tv, NULL);
 
-    unsigned long long millisecondsSinceEpoch =
-            (unsigned long long)(tv.tv_sec) * 1000 +
-            (unsigned long long)(tv.tv_usec) / 1000;
+    // unsigned long long millisecondsSinceEpoch =
+    //         (unsigned long long)(tv.tv_sec) * 1000 +
+    //         (unsigned long long)(tv.tv_usec) / 1000;
 
 
     // generate log level string
@@ -94,13 +96,13 @@ char * get_log_message_string(log_level max_log_level, log_level level, char * l
     }
 
     // format timestamp
-    strftime(timestamp, sizeof(timestamp), "%x|%X", time_info);
+    // strftime(timestamp, sizeof(timestamp), "%x|%X", time_info);
 
     // add milliseconds to timestamp
-    sprintf(timestamp2, "%s (Epoch time: %llu)", timestamp, millisecondsSinceEpoch);
+    // sprintf(timestamp2, "%s (Epoch time: %llu)", timestamp, millisecondsSinceEpoch);
 
     char *  msg_string = rmalloc(LOGGER_MAX_MSG_SIZE);
-    sprintf(msg_string, LOG_FORMAT, timestamp2, level_str, location, msg_str);
+    sprintf(msg_string, LOG_FORMAT, "", level_str, location, msg_str);
 
     return msg_string;
 }

--- a/src/rasta/c/rasta_new.c
+++ b/src/rasta/c/rasta_new.c
@@ -1726,13 +1726,6 @@ void sr_cleanup(struct rasta_handle *h) {
     h->recv_running = 0;
     h->send_running = 0;
 
-    // Due to the unset running flags above, the threads may already be exiting.
-    // Do not cancel them since this might lead to an already exiting thread to not free its malloc arena locks.
-    // https://stackoverflow.com/questions/49701888/how-can-i-find-out-the-source-of-this-glibc-backtrace-originating-with-clone
-    // > It turns out this bug was caused by pthread_cancel using asynchronous cancel type. Essentially, we believe that pthread_cancel
-    // > was cancelling a thread while it was exiting, i.e. while it was holding the arena locks. Thus, all the other threads deadlock on
-    // > the arena lock either when they call malloc or when they exit, since it is held by a thread that no longer exists.
-
     // cancel receive thread
     pthread_cancel(h->receive_handle->recv_thread);
     pthread_join(h->receive_handle->recv_thread, NULL);

--- a/src/rasta/c/rasta_red_multiplexer.c
+++ b/src/rasta/c/rasta_red_multiplexer.c
@@ -322,7 +322,7 @@ void * channel_receive_handler(void * arg_wrapper){
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
     // set cancel type to async, i.e. can always be canceled
-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
 
     struct receive_thread_parameter_wrapper * args = (struct receive_thread_parameter_wrapper*)arg_wrapper;
 
@@ -723,6 +723,7 @@ void redundancy_mux_close(redundancy_mux * mux){
     for (int i = 0; i < mux->port_count; ++i) {
         logger_log(&mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux close", "closing udp socket %d/%d", i+1, mux->port_count);
         pthread_cancel(mux->transport_receive_threads[i]);
+        pthread_join(mux->transport_receive_threads[i], NULL);
         udp_close(mux->udp_socket_fds[i]);
     }
 
@@ -734,6 +735,7 @@ void redundancy_mux_close(redundancy_mux * mux){
 
     // cancel the timeout thread
     pthread_cancel(mux->timeout_thread);
+    pthread_join(mux->timeout_thread, NULL);
 
     // close the redundancy channels
     for (int j = 0; j < mux->channel_count; ++j) {

--- a/src/rasta/c/rasta_red_multiplexer.c
+++ b/src/rasta/c/rasta_red_multiplexer.c
@@ -320,8 +320,6 @@ void receive_packet(redundancy_mux * mux, int channel_id){
 void * channel_receive_handler(void * arg_wrapper){
     // enable possibility to cancel thread
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-
-    // set cancel type to async, i.e. can always be canceled
     pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
 
     struct receive_thread_parameter_wrapper * args = (struct receive_thread_parameter_wrapper*)arg_wrapper;


### PR DESCRIPTION
This attempts to fix some threading-related issues.

Foremost, the use of `pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);` was a source of deadlocks related to heap management: In many cases, threads are signalled to shut down via some shared data structure and while cleaning up their thread-related state in the global malloc arena, a `pthread_cancel` call in combination with `PTHREAD_CANCEL_ASYNCHRONOUS` would force them to quit immediately (thus global malloc-locks held by the thread were not freed).

I'd propose a different mode of operation:
 - If a thread should be shut down, this has to be signalled via some shared variable
 - The calling thread should not use `pthread_cancel`, but instead use `pthread_join` to ensure that the shutdown request completed as planned.
 - In general, the use of pthreads in this codebase is a source of race conditions and deadlocks and should be avoided whenever possible. My suggestion is to port the implementation to use an eventing library (e.g. libevent, libev, libuv), which would simplify the code and also pave a way towards supporting TCP/TLS as well as platform-independence (i.e. Windows/macOS).