### PR TITLE
CMake: Add option to generate documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required(VERSION 3.6.2)
-project(rasta C)
+cmake_minimum_required(VERSION 3.12)
+project(rasta
+    LANGUAGES C
+    DESCRIPTION "A C implementation of the RaSTA protocol stack")
 
 set(CMAKE_C_STANDARD 11)
 
 SET(USE_OPENSSL false CACHE BOOL "Use OpenSSL MD4 implementation")
 
+option(BUILD_DOCUMENTATION "Generate documentation" OFF)
 option(BUILD_LOCAL_EXAMPLES "Build the RaSTA/SCI examples the run on localhost" ON)
 option(BUILD_REMOTE_EXAMPLES "Build the RaSTA/SCI examples that communicate in a network" ON)
 option(EXAMPLE_IP_OVERRIDE "Use IPs from environment variables in RaSTA/SCI examples" OFF)
@@ -101,6 +104,37 @@ install(TARGETS rasta
 
 # Enable optimization for RaSTA
 target_compile_options(rasta PRIVATE -O3)
+
+if(BUILD_DOCUMENTATION)
+    find_package(Doxygen REQUIRED dot)
+
+    set(DOXYGEN_PROJECT_NAME "Librasta & Libsci")
+    set(DOXYGEN_OUTPUT_DIRECTORY "doc")
+    set(DOXYGEN_CREATE_SUBDIRS YES)
+    set(DOXYGEN_OPTIMIZE_OUTPUT_FOR_C YES)
+    set(DOXYGEN_BUILTIN_STL_SUPPORT YES)
+    set(DOXYGEN_EXTRACT_ALL YES)
+    set(DOXYGEN_EXTRACT_STATIC YES)
+    set(DOXYGEN_EXTRACT_ANON_NSPACES YES)
+    set(DOXYGEN_CASE_SENSE_NAMES NO)
+    set(DOXYGEN_WARN_NO_PARAMDOC YES)
+    set(DOXYGEN_RECURSIVE YES)
+    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "README.md")
+    set(DOXYGEN_INLINE_SOURCES YES)
+    set(DOXYGEN_GENERATE_MAN YES)
+    set(DOXYGEN_MACRO_EXPANSION YES)
+    set(DOXYGEN_HIDE_UNDOC_RELATIONS NO)
+    if(DOXYGEN_FOUND)
+        doxygen_add_docs(
+            documentation
+            src/rasta/headers
+            src/sci/headers
+            README.md
+            md_doc/
+            ALL
+            COMMENT "Generate documentation")
+    endif(DOXYGEN_FOUND)
+endif(BUILD_DOCUMENTATION)
 
 if(BUILD_LOCAL_EXAMPLES)
 	# scip_example on localhost


### PR DESCRIPTION
Part of #4.

`doxygen_add_docs()` was added in CMake 3.9 and the `ALL` option in CMake 3.12.