### PR TITLE
CMake: Support testing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install CUnit
+      run: sudo apt-get install libcunit1 libcunit1-doc libcunit1-dev
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(BUILD_LOCAL_EXAMPLES "Build the RaSTA/SCI examples the run on localhost" 
 option(BUILD_REMOTE_EXAMPLES "Build the RaSTA/SCI examples that communicate in a network" ON)
 option(EXAMPLE_IP_OVERRIDE "Use IPs from environment variables in RaSTA/SCI examples" OFF)
 
+include(CTest)
 include(GNUInstallDirs)
 
 include_directories(
@@ -135,6 +136,61 @@ if(BUILD_DOCUMENTATION)
             COMMENT "Generate documentation")
     endif(DOXYGEN_FOUND)
 endif(BUILD_DOCUMENTATION)
+
+if(BUILD_TESTING)
+    include(FindPkgConfig)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(CUnit IMPORTED_TARGET cunit)
+    endif(PKG_CONFIG_FOUND)
+
+    add_executable(rastaTest
+        src/rastaTest/headers/blake2test.h
+        src/rastaTest/headers/configtest.h
+        src/rastaTest/headers/dictionarytest.h
+        src/rastaTest/headers/fifotest.h
+        src/rastaTest/headers/rastacrcTest.h
+        src/rastaTest/headers/rastadeferqueueTest.h
+        src/rastaTest/headers/rastafactoryTest.h
+        src/rastaTest/headers/rastalisttest.h
+        src/rastaTest/headers/rastamd4Test.h
+        src/rastaTest/headers/rastamoduleTest.h
+        src/rastaTest/headers/registerTests.h
+        src/rastaTest/headers/siphash24test.h
+        src/rastaTest/c/blake2test.c
+        src/rastaTest/c/configtest.c
+        src/rastaTest/c/dictionarytest.c
+        src/rastaTest/c/fifotest.c
+        src/rastaTest/c/rastacrcTest.c
+        src/rastaTest/c/rastadeferqueueTest.c
+        src/rastaTest/c/rastafactoryTest.c
+        src/rastaTest/c/rastalisttest.c
+        src/rastaTest/c/rastamd4Test.c
+        src/rastaTest/c/rastamoduleTest.c
+        src/rastaTest/c/registerTests.c
+        src/rastaTest/c/siphash24test.c)
+    target_include_directories(rastaTest PRIVATE src/rastaTest/headers assets/include_gradle/)
+    target_link_libraries(rastaTest rasta PkgConfig::CUnit)
+    target_compile_definitions(rastaTest PRIVATE WITH_CMAKE)
+
+    add_test(NAME test_rastaTest
+             COMMAND rastaTest)
+
+    add_executable(sciTest
+        src/sciTest/headers/registerTests.h
+        src/sciTest/headers/scilsTests.h
+        src/sciTest/headers/scipTests.h
+        src/sciTest/headers/sciTests.h
+        src/sciTest/c/registerTests.c
+        src/sciTest/c/scilsTests.c
+        src/sciTest/c/scipTests.c
+        src/sciTest/c/sciTests.c)
+    target_include_directories(sciTest PRIVATE src/sciTest/headers assets/include_gradle/)
+    target_link_libraries(sciTest rasta PkgConfig::CUnit)
+    target_compile_definitions(sciTest PRIVATE WITH_CMAKE)
+
+    add_test(NAME test_sciTest
+             COMMAND sciTest)
+endif(BUILD_TESTING)
 
 if(BUILD_LOCAL_EXAMPLES)
 	# scip_example on localhost

--- a/src/rastaTest/c/rastamd4Test.c
+++ b/src/rastaTest/c/rastamd4Test.c
@@ -133,7 +133,7 @@ void testRastaMD4Sample() {
 
     //std context
 
-    MD4_CTX context = md4InitContext(0x67452301,0xefcdab89,0x98badcfe,0x10325476);
+    MD4_CONTEXT context = md4InitContext(0x67452301,0xefcdab89,0x98badcfe,0x10325476);
 
     //holder for md4
     unsigned char calc_md4[16];

--- a/src/rastaTest/c/registerTests.c
+++ b/src/rastaTest/c/registerTests.c
@@ -84,3 +84,17 @@ void gradle_cunit_register() {
     // Tests for BLAKE2 hashes
     CU_add_test(pSuiteMath, "testBlake2Hash", testBlake2Hash);
 }
+
+#ifdef WITH_CMAKE
+int main () {
+    if (CUE_SUCCESS != CU_initialize_registry())
+        return CU_get_error();
+
+    gradle_cunit_register();
+
+    CU_basic_run_tests();
+    int ret = CU_get_number_of_failures();
+    CU_cleanup_registry();
+    return ret;
+}
+#endif

--- a/src/sciTest/c/registerTests.c
+++ b/src/sciTest/c/registerTests.c
@@ -50,3 +50,17 @@ void gradle_cunit_register() {
     CU_add_test(sci_suite, "testParseChangeBrightness", testParseChangeBrightness);
     CU_add_test(sci_suite, "testParseBrightnessStatus", testParseBrightnessStatus);
 }
+
+#ifdef WITH_CMAKE
+int main () {
+    if (CUE_SUCCESS != CU_initialize_registry())
+        return CU_get_error();
+
+    gradle_cunit_register();
+
+    CU_basic_run_tests();
+    int ret = CU_get_number_of_failures();
+    CU_cleanup_registry();
+    return ret;
+}
+#endif


### PR DESCRIPTION
To run tests, call `ctest` or `ctest -V` in build directory.

To check for memory leaks run `ctest -T memcheck`.
(Requires valgrind.)

Part of #4.